### PR TITLE
Add setup_cmd option for a pre-session command

### DIFF
--- a/load-tmux-profile.rb
+++ b/load-tmux-profile.rb
@@ -106,8 +106,16 @@ def load_profile profile_name, attach_to=nil
     w = `tput cols`.strip
     h = `tput lines`.strip
 
-    # create session
     current_dir = session["dir"] || window["dir"]
+    
+    # run setup command for session
+    setup_cmd = session["setup_cmd"]
+    puts setup_cmd
+    if setup_cmd
+      run "cd #{current_dir} && #{setup_cmd}"
+    end
+
+    # create session
     args = []
     args << "-s #{session["name"]}"
     args << "-n #{window["name"]}"


### PR DESCRIPTION
I had the use case that I wanted to ensure my docker-compose stuff is up and running before the tmux session was started. So I added this funcionality